### PR TITLE
Bump version to 1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.andmcadams.taskchecker'
-version = '1.1.1'
+version = '1.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/andmcadams/taskchecker/Varbits.java
+++ b/src/main/java/com/andmcadams/taskchecker/Varbits.java
@@ -57,7 +57,7 @@ public enum Varbits
 	/**
 	 * Motherlode Mine
 	 */
-	// Upstairs mines access?
+	// Upstairs mines access has no varb/varp :(
 	// Bigger sack? probably 5556
 	UPGRADED_MLM_SACK(5556),
 
@@ -71,6 +71,8 @@ public enum Varbits
 	 */
 	// Large water container?
 	// Fertile soil warning?
+	UNLOCKED_LARGE_WATER_CONTAINER(5959),
+	// ash covered tome bought is 5960
 
 	/**
 	 * Ava's effects
@@ -116,6 +118,7 @@ public enum Varbits
 	 * Graceful outfits
 	 */
 	// Ability to buy single Agility Arena recolours?
+	UNLOCKED_BRIMHAVEN_SINGLE_RECOLORS(5967),
 
 	/**
 	 * Bounty Hunter rewards
@@ -233,6 +236,7 @@ public enum Varbits
 	UNLOCKED_ENAKHRAS_TEMPLE_E_DOOR(1614),
 
 	EXCAVATED_STATUE_TO_TUNNEL_OF_CHAOS(3524),
+	EXITED_THROUGH_TROLL_STRONGHOLD_SECRET_EXIT(1),
 
 	/**
 	 * Dialogue box menu options
@@ -378,6 +382,13 @@ public enum Varbits
 	INFORMED_KNIGHT_OF_VARLAMORE(8409),
 	MET_FAIRY_AERYKA(3728),
 	MET_SILAS_DAHCSNU(3528),
+	MET_DAMPE(11774),
+	MET_DRUNKEN_DWARF(574),
+	RECEIVE_THANKS_FROM_HAMAL(272),
+	BOUGHT_CANDLE_FROM_CANDLE_SELLER(284),
+	CLAIMED_RAMS_SKULL_HELM(2048),
+	CLAIMED_BONESACK(2049),
+	ASKED_ABOUT_GUARD_UNIFORM(2495),
 
 	/**
 	 * Loot tasks
@@ -410,6 +421,11 @@ public enum Varbits
 	// 2310, 9374, 0
 	OBSERVATORY_SPIDER_CHEST_7(3835),
 	ZEAH_WORKBENCH_NAILS(9684),
+	PISCATORIS_BRONZE_PICKAXE(2109),
+	PISCATORIS_BRONZE_AXE(2110),
+	ANCIENT_LETTER_FORSAKEN_TOWER(7810),
+	TATTY_NOTE_KEBOS_LOWLANDS(7951),
+	PICKPOCKETED_TEDDY(2559),
 
 	/**
 	 * Fire pits

--- a/src/main/java/com/andmcadams/taskchecker/tasklist/EntrancesAndObstaclesTaskList.java
+++ b/src/main/java/com/andmcadams/taskchecker/tasklist/EntrancesAndObstaclesTaskList.java
@@ -100,6 +100,11 @@ public class EntrancesAndObstaclesTaskList extends TaskList
 			.switchVar(true, Varbits.EXCAVATED_STATUE_TO_TUNNEL_OF_CHAOS.getId())
 			.build();
 
+		Task exitThroughSecretExit = new Task.TaskBuilder()
+			.name("Exit through the Troll Stronghold's secret exit")
+			.switchVar(true, Varbits.EXITED_THROUGH_TROLL_STRONGHOLD_SECRET_EXIT.getId())
+			.build();
+
 		add(unblockLumbridgeSwampCavesHole);
 		add(unblockEagleTransport);
 		add(unblockKourendCatacombsEntrances);
@@ -110,6 +115,6 @@ public class EntrancesAndObstaclesTaskList extends TaskList
 		add(unlockEnakhrasTempleEntrances);
 		add(unlockEnakhrasTempleSigilDoors);
 		add(excavateStatue);
-
+		add(exitThroughSecretExit);
 	}
 }

--- a/src/main/java/com/andmcadams/taskchecker/tasklist/LootTaskList.java
+++ b/src/main/java/com/andmcadams/taskchecker/tasklist/LootTaskList.java
@@ -115,6 +115,27 @@ public class LootTaskList extends TaskList
 			.switchVar(true, Varbits.ZEAH_WORKBENCH_NAILS.getId())
 			.build();
 
+		Task piscatorisTools = new Task.TaskBuilder()
+			.name("Loot the bronze axe and pickaxe in the Piscatoris fishing colony")
+			.switchVar(true, Varbits.PISCATORIS_BRONZE_PICKAXE.getId())
+			.switchVar(true, Varbits.PISCATORIS_BRONZE_AXE.getId())
+			.build();
+
+		Task ancientLetter = new Task.TaskBuilder()
+			.name("Loot the Ancient letter from the Forsake Tower")
+			.switchVar(true, Varbits.ANCIENT_LETTER_FORSAKEN_TOWER.getId())
+			.build();
+
+		Task tattyNote = new Task.TaskBuilder()
+			.name("Loot the Tatty note from the bed in the Kebos Lowlands")
+			.switchVar(true, Varbits.TATTY_NOTE_KEBOS_LOWLANDS.getId())
+			.build();
+
+		Task pickpocketTeddy = new Task.TaskBuilder()
+			.name("Pickpocket Teddy from the female student in the Digsite")
+			.switchVar(true, Varbits.PICKPOCKETED_TEDDY.getId())
+			.build();
+
 		add(openMarlosCrate);
 		add(searchMorttonTable);
 		add(undergroundPassCrate);
@@ -128,5 +149,9 @@ public class LootTaskList extends TaskList
 		add(goblinVillageGoblinMail);
 		add(observatorySpiderChests);
 		add(zeahWorkbenchNails);
+		add(piscatorisTools);
+		add(ancientLetter);
+		add(tattyNote);
+		add(pickpocketTeddy);
 	}
 }

--- a/src/main/java/com/andmcadams/taskchecker/tasklist/UniqueDialoguePathsTaskList.java
+++ b/src/main/java/com/andmcadams/taskchecker/tasklist/UniqueDialoguePathsTaskList.java
@@ -134,7 +134,7 @@ public class UniqueDialoguePathsTaskList extends TaskList
 
 		// Note that this doesn't actually change dialogue as far as I can tell.
 		Task askBlackKnightFortressGuardAboutUniform = new Task.TaskBuilder()
-			.name("Ask a Fortress guard about their uniform outside the Black knights' fortress")
+			.name("Ask a Fortress guard about their uniform outside the Black Knights' Fortress")
 			.switchVar(true, Varbits.ASKED_ABOUT_GUARD_UNIFORM.getId())
 			.build();
 

--- a/src/main/java/com/andmcadams/taskchecker/tasklist/UniqueDialoguePathsTaskList.java
+++ b/src/main/java/com/andmcadams/taskchecker/tasklist/UniqueDialoguePathsTaskList.java
@@ -106,6 +106,38 @@ public class UniqueDialoguePathsTaskList extends TaskList
 			.switchVar(true, Varbits.MET_SILAS_DAHCSNU.getId())
 			.build();
 
+		Task meetDampe = new Task.TaskBuilder()
+			.name("Listen to Dampe explain shade coffins")
+			.switchVar(true, Varbits.MET_DAMPE.getId())
+			.build();
+
+		Task meetDrunkenDwarf = new Task.TaskBuilder()
+			.name("Listen to the Drunken Dwarf talk about his relative")
+			.switchVar(true, Varbits.MET_DRUNKEN_DWARF.getId())
+			.build();
+
+		Task receiveThanksFromHamal = new Task.TaskBuilder()
+			.name("Receive thanks from Hamal after completing Mountain Daughter")
+			.switchVar(true, Varbits.RECEIVE_THANKS_FROM_HAMAL.getId())
+			.build();
+
+		Task buyCandleFromCandleSeller = new Task.TaskBuilder()
+			.name("Buy a candle from the Candle Seller in Lumbridge Swamp and listen to his warning")
+			.switchVar(true, Varbits.BOUGHT_CANDLE_FROM_CANDLE_SELLER.getId())
+			.build();
+
+		Task claimRagAndBoneManIIRewards = new Task.TaskBuilder()
+			.name("Claim the Rams skull helm and Bonesack from the Odd old man")
+			.switchVar(true, Varbits.CLAIMED_RAMS_SKULL_HELM.getId())
+			.switchVar(true, Varbits.CLAIMED_BONESACK.getId())
+			.build();
+
+		// Note that this doesn't actually change dialogue as far as I can tell.
+		Task askBlackKnightFortressGuardAboutUniform = new Task.TaskBuilder()
+			.name("Ask a Fortress guard about their uniform outside the Black knights' fortress")
+			.switchVar(true, Varbits.ASKED_ABOUT_GUARD_UNIFORM.getId())
+			.build();
+
 		add(unlockRosie);
 		add(getDirectionsFromBaraek);
 		add(buyStaffFromEblis);
@@ -118,6 +150,12 @@ public class UniqueDialoguePathsTaskList extends TaskList
 		add(informKnightOfVarlamore);
 		add(meetFairyAeryka);
 		add(meetSilasDahcsnu);
+		add(meetDampe);
+		add(meetDrunkenDwarf);
+		add(receiveThanksFromHamal);
+		add(buyCandleFromCandleSeller);
+		add(claimRagAndBoneManIIRewards);
+		add(askBlackKnightFortressGuardAboutUniform);
 	}
 
 }


### PR DESCRIPTION
Add new varbits and associated tasks:
- Secret exit in the Troll Stronghold*
- Piscatoris tools, Ancient letter*, Tatty note*, and Teddy* loot tasks
- Dampe and Drunken dwarf initial dialogue, Hamal post quest dialogue,  Candle seller dialogue, Black Knights' Fortress guard dialogue*
- Rag and Bone Man II rewards claimed (changes dialogue of Odd old man)
*These have no known effect other than setting the varbit